### PR TITLE
Add Cloudflare Worker for storing webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# webhook_data_to_db
+# Webhook Worker
+
+This Cloudflare Worker receives webhook events from the subscription service and stores the raw JSON payloads in Supabase.
+
+## Setup
+
+1. Set up a table named `webhook_events` in your Supabase database. The table should contain at least one JSONB column called `payload` to store the webhook payload.
+2. Provide `SUPABASE_URL` and `SUPABASE_KEY` to the worker. These can be defined in `wrangler.toml` or set as secrets using `wrangler secret put`.
+3. Deploy the worker using [`wrangler`](https://developers.cloudflare.com/workers/wrangler/).
+
+```bash
+wrangler deploy
+```
+
+The worker accepts `POST` requests at the root path and inserts the received JSON body into Supabase.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,37 @@
+export interface Env {
+  SUPABASE_URL: string;
+  SUPABASE_KEY: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method !== 'POST') {
+      return new Response('Not found', { status: 404 });
+    }
+
+    let payload: any;
+    try {
+      payload = await request.json();
+    } catch (err) {
+      return new Response('Invalid JSON', { status: 400 });
+    }
+
+    const res = await fetch(`${env.SUPABASE_URL}/rest/v1/webhook_events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: env.SUPABASE_KEY,
+        Authorization: `Bearer ${env.SUPABASE_KEY}`,
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify({ payload }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return new Response(`Supabase error: ${text}`, { status: 500 });
+    }
+
+    return new Response('ok');
+  },
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "webhook-worker"
+main = "src/worker.ts"
+compatibility_date = "2024-05-01"
+
+[vars]
+# Define SUPABASE_URL and SUPABASE_KEY in production or via wrangler secrets


### PR DESCRIPTION
## Summary
- create a Worker script that saves webhook payloads in Supabase
- configure wrangler
- document how to deploy

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ced79c2cc83328d2a6259c8633074